### PR TITLE
fix(community-projects.md): fix cnab-netstandard repo URL

### DIFF
--- a/content/community-projects.md
+++ b/content/community-projects.md
@@ -45,7 +45,7 @@ Feel free to contribute to that SDK, or start your own.
 * [cnab-go](https://github.com/cnabio/cnab-go)
 
 ## .NET
-* [CNAB.NET](https://github.com/cnabio/cnab-netstandard)
+* [CNAB.NET](https://github.com/deislabs/cnab-netstandard)
 
 ## Python
 * [CNAB](https://github.com/garethr/pycnab)


### PR DESCRIPTION
* Fixes URL for https://github.com/deislabs/cnab-netstandard (broken via search-replace in https://github.com/cnabio/cnab.io/pull/23)