### PR TITLE
feat(_redirects): add splat redirect for versioned schema

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,10 +1,13 @@
 # Redirect rules for Netlify
 # Although splats are supported, e.g. /* /new/path/:splat, regex isn't yet
 
-# Serve schema files located in the cnabio/cnab-spec repository
+# Serve latest schema files located in the cnabio/cnab-spec repository
 /v1/bundle.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/bundle.schema.json
 /v1/claim.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/claim.schema.json
 /v1/definitions.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/definitions.schema.json
 /v1/dependencies.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/dependencies.schema.json
 /v1/relocation-mapping.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/relocation-mapping.schema.json
 /v1/status.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/status.schema.json
+
+# Serve versioned schema files from the CDN source
+/schema/* https://cdn.cnab.io/schema/*

--- a/static/_redirects
+++ b/static/_redirects
@@ -10,4 +10,4 @@
 /v1/status.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/status.schema.json
 
 # Serve versioned schema files from the CDN source
-/schema/* https://cdn.cnab.io/schema/*
+/schema/* https://cdn.cnab.io/schema/:splat


### PR DESCRIPTION
* Adds redirect for versioned schema files hosted by the CDN source

Deploy Preview: https://deploy-preview-32--cnabio.netlify.com/
Sample: https://deploy-preview-32--cnabio.netlify.com/schema/cnab-core-1.0/bundle.schema.json

Ref https://github.com/cnabio/cnab-spec/pull/350