### PR TITLE
docs(index.html): remove deislabs/example-bundles link

### DIFF
--- a/themes/cnab/layouts/index.html
+++ b/themes/cnab/layouts/index.html
@@ -93,18 +93,21 @@
         </div>
 
         <div class="row">
-            <div class="small-12 large-8 columns">
+            <!-- TODO: replace this commented-out entry with other CNAB example entries (in Duffle, Porter, Docker App, etc.) -->
+            <!-- See https://github.com/cnabio/cnab.io/issues/35 -->
+            <!-- Note: entry below commented-out as the linked repository is deprecated -->
+            <!-- <div class="small-12 large-8 columns">
               <div class="panel panel-bundles panel-green">
                 <a href="https://github.com/deislabs/example-bundles">
                   <h4>
                     <i class="fa fa-th-large" aria-hidden="true"></i>&nbsp;
                     Sample Bundles
                   </h4>
-                  <!-- <img src="../img/vscode.png" class="resource-vscode" alt="VS Code Extension" class="left" /> -->
+                  <img src="../img/vscode.png" class="resource-vscode" alt="VS Code Extension" class="left" />
                   <p>A resource of ready-to-use CNAB bundles and examples to help you create your own. &nbsp;<i class="fa fa-caret-right" aria-hidden="true"></i></p>
                 </a>
               </div>
-            </div>
+            </div> -->
             <div class="small-12 large-4 columns">
               <div class="panel panel-vscode panel-yellowl">
                 <a href="https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.duffle-vscode" title="VS Code Extension">


### PR DESCRIPTION
Currently, this simply removes an entry for the deislabs/example-bundles repo, as it is deprecated.

Would also be open to replacing with a link to either the examples in the cnabio/duffle repo or another suggestion.

Closes https://github.com/cnabio/cnab.io/issues/26