### PR TITLE
ref(_redirects): reduce v1 schema paths to splat

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -2,12 +2,7 @@
 # Although splats are supported, e.g. /* /new/path/:splat, regex isn't yet
 
 # Serve latest schema files located in the cnabio/cnab-spec repository
-/v1/bundle.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/bundle.schema.json
-/v1/claim.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/claim.schema.json
-/v1/definitions.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/definitions.schema.json
-/v1/dependencies.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/dependencies.schema.json
-/v1/relocation-mapping.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/relocation-mapping.schema.json
-/v1/status.schema.json https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/status.schema.json
+/v1/* https://raw.githubusercontent.com/cnabio/cnab-spec/master/schema/:splat
 
 # Serve versioned schema files from the CDN source
 /schema/* https://cdn.cnab.io/schema/:splat


### PR DESCRIPTION
I originally was going to create a PR to add another path for a new schema file (https://github.com/cnabio/cnab-spec/blob/master/schema/claim-result.schema.json) but decided perhaps it would be best to just reduce to one wildcard/splat line.  

Although Netlify doesn't yet support regex matching - it would be preferable to match on `*.schema.json` - I'm thinking since the source path is in the `schema` directory of the GH repo, we should be fine.  (Invalid paths referencing files that do not exist in this folder will 404.)  My idea is that the benefit of not having to update/maintain the list here (after schemas are added/removed in the separate GH cnab-spec repo) outweighs the lack of precision in url matching.

Preview at https://deploy-preview-36--cnabio.netlify.app/