### PR TITLE
Mark GCR as unsupported, and Artifact Registry as supported

### DIFF
--- a/content/registries.md
+++ b/content/registries.md
@@ -19,7 +19,8 @@ using a CNAB tool that uses the [cnab-to-oci] library.
 | **Docker Hub** | **Yes** |
 | **DigitalOcean Container Registry** | **Yes** |
 | Amazon Elastic Container Registry (ECR) | No |
-| **Google Cloud Registry (GCR)** | **Yes** | 
+| **Google Artifact Registry** | **Yes** |
+| Google Cloud Registry (GCR) | No | 
 | **GitHub Container Registry (GHCR)** | **Yes** | 
 | GitHub Packages | No |
 | **Harbor 2** | **Yes** |


### PR DESCRIPTION
In https://github.com/getporter/porter/issues/1332, @iennae discovered that Google Cloud Registry does not support CNAB, however their new offering Google Artifact Registry does.
