### PR TITLE
Fix footer logo

### DIFF
--- a/themes/cnab/layouts/partials/footer.html
+++ b/themes/cnab/layouts/partials/footer.html
@@ -4,7 +4,7 @@
     <div class="show-for-large-up large-1 columns">&nbsp;</div>
     <div class="small-9 large-8 columns">
       <ul class="inline inline-list show-for-large-up">
-        <li><img src="img/logo.png" alt="CNAB" class="logo" /></li>
+        <li><img src="/img/logo.png" alt="CNAB" class="logo" /></li>
         <li><strong>CNAB</strong></li>
         <li><a href="https://github.com/cnabio/community">Community</a></li>
         <li><a href="https://github.com/cnabio/cnab-spec/blob/main/CONTRIBUTING.md">Contributing</a></li>


### PR DESCRIPTION
The footer logo was not rendering on pages in a sub-directory.

https://deploy-preview-51--cnabio.netlify.app/registries/ (vs https://cnab.io/registries/)

![Screen Shot 2021-04-10 at 9 00 04 AM](https://user-images.githubusercontent.com/1368985/114272276-2904cc80-99db-11eb-8952-40da81aa7dfe.png)