### PR TITLE
Add short links for zoom and hackmd

### DIFF
--- a/content/community-meetings.md
+++ b/content/community-meetings.md
@@ -10,18 +10,20 @@ Each week the CNAB community meets to discuss and demo ongoing work around the s
 ## General Community Meeting
 
 * Meeting Time: Every other Wednesday 9:00 AM - 10:00 AM US Pacific Time. See exact dates in our [Google Calendar](https://calendar.google.com/calendar/r?cid=Nzg5aTBsMzIzaGZmNzc1b3VwZTZxNDVmbXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&pli=1).
-* [Join Meeting](https://zoom.us/j/653255416) with the passcode `77777`.
-* [Agenda and Notes](https://hackmd.io/s/SyGcBcwQ4#)
+* [Join Meeting](https://cnab.io/zoom) with the passcode `77777`.
+* [Agenda and Notes](https://cnab.io/agenda)
 
 ## Registry and Security Community Meeting
 
+This meeting is not currently active.
+
 * Meeting Time: Every other Wednesday 9:00 AM - 10:00 AM US Pacific Time. See exact dates in our [Google Calendar](https://calendar.google.com/calendar/r?cid=Nzg5aTBsMzIzaGZmNzc1b3VwZTZxNDVmbXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&pli=1).
-* [Join Meeting](https://zoom.us/j/653255416) with the passcode `77777`
-* [Agenda and Notes](https://hackmd.io/s/SyGcBcwQ4#)
+* [Join Meeting](https://cnab.io/zoom) with the passcode `77777`
+* [Agenda and Notes](https://cnab.io/agenda)
 
 ### Agenda & Action Items
 
-Agenda notes and action items for all community meetings are tracked in a collaborative [document](https://hackmd.io/s/SyGcBcwQ4#) that all participants
+Agenda notes and action items for all community meetings are tracked in a collaborative [document](https://cnab.io/agenda) that all participants
 may edit.
 
 ### Previous Meetings

--- a/static/_redirects
+++ b/static/_redirects
@@ -6,3 +6,7 @@
 
 # Serve versioned schema files from the CDN source
 /schema/* https://cdn.cnab.io/schema/:splat
+
+# shortlinks
+/zoom https://us02web.zoom.us/j/89658023321?pwd=UW9NY0NSM015ZXE3bHVrL2Rqa1lzdz09
+/agenda https://hackmd.io/s/SyGcBcwQ4#


### PR DESCRIPTION
* https://cnab.io/zoom now goes to Carolyn's zoom meeting for CNAB.
* https://cnab.io/agenda goes to our hackmd with the meeting agenda.
* Updated meetings page to use shortlinks